### PR TITLE
fix: ensure the shell function is always called

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -40,6 +40,7 @@ You MUST NOT use functions that are not available.`,
         },
       },
     ],
+    function_call: { name: "shell" },
   });
 
   return response;

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,10 +38,7 @@ export async function main(argv: string[]) {
   );
 
   for (const choice of response.choices) {
-    if (
-      choice.finish_reason === "function_call" &&
-      choice.message.function_call
-    ) {
+    if (choice.message.function_call) {
       const fnCall = choice.message.function_call;
       const execute = commands[fnCall.name];
       if (!execute) {


### PR DESCRIPTION
Two changes:
1. Ensure the shell function is always called using the `function_call` parameter on the [completion](https://platform.openai.com/docs/guides/gpt/function-calling#:~:text=function_call%3A%20%22auto%22%2C%20%20//%20auto%20is%20default%2C%20but%20we%27ll%20be%20explicit)
2. Handle messages that are function calls but don't have the `function_call` finish reason.