### PR TITLE
fix: make params required and rename content to command

### DIFF
--- a/src/commands/shell.ts
+++ b/src/commands/shell.ts
@@ -2,7 +2,7 @@ import Enquirer from "enquirer";
 import { executeShellCommand } from "../utils.js";
 
 interface ShellOptions {
-  content: string;
+  command: string;
   description: string;
 }
 
@@ -13,7 +13,7 @@ export async function shell(options: ShellOptions) {
     type: "confirm",
     message: `${options.description}
 
-Are you sure you want to run: ${options.content}?`,
+Are you sure you want to run: ${options.command}?`,
     name: "confirm",
   });
 
@@ -21,5 +21,5 @@ Are you sure you want to run: ${options.content}?`,
     console.log("Aborting...");
     return;
   }
-  await executeShellCommand(options.content);
+  await executeShellCommand(options.command);
 }

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -31,12 +31,13 @@ You MUST NOT use functions that are not available.`,
               description:
                 "A description of what this command will do. If it will cause any side effects, highlight with a warning.",
             },
-            content: {
+            command: {
               type: "string",
               description:
                 "The shell command to run (e.g. ls -l). Use appropriate command based on the shell and OS.",
             },
           },
+          required: ["description", "command"],
         },
       },
     ],


### PR DESCRIPTION
Renames the "content" param to "command" for better prompting, and marks the params as required.
Fixes things like https://github.com/searchableguy/whiz/issues/4